### PR TITLE
Amend gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,5 @@ ssl/*
 *.db
 .vscode
 .env
-depot_overview.pdf
-depotlist.pdf
+media
 __pycache__

--- a/basimilch/management/commands/generate_depot_list.py
+++ b/basimilch/management/commands/generate_depot_list.py
@@ -5,4 +5,3 @@ from django.core.management.base import BaseCommand
 class Command(BaseCommand):
     def handle(self, *args, **options):
         call_command('cs_generate_depot_list')
-        call_command('cs_generate_pack_list')


### PR DESCRIPTION
As I added a amount_overview.pdf into the media folder, which ensures that the app does not return 500 when someone clicks on "Listen>Mengenübersicht", I feel it's a bit more convenient to simple ignore the media folder instead of each individual file. 

Also, 'cs_generate_pack_list' is no longer a valid management command. 